### PR TITLE
Implement concatstrings, anytostring and objtostring

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -250,6 +250,8 @@ module YARV
           # skip for now
         in Symbol
           @labels[insn] = @insns.length
+        in [:anytostring]
+          @insns << AnyToString.new
         in :branchif, value
           @insns << BranchIf.new(value)
         in :branchnil, value
@@ -258,6 +260,8 @@ module YARV
           @insns << BranchUnless.new(value)
         in [:concatarray]
           @insns << ConcatArray.new
+        in :concatstrings, num
+          @insns << ConcatStrings.new(num)
         in :definemethod, name, iseq
           @insns << DefineMethod.new(name, InstructionSequence.new(selfo, iseq))
         in [:dup]
@@ -285,6 +289,8 @@ module YARV
           @insns << NewHash.new(size)
         in :newrange, exclude_end
           @insns << NewRange.new(exclude_end)
+        in :objtostring, { mid: :to_s, orig_argc: 0, flag: }
+          @insns << ObjToString.new(CallData.new(:to_s, 0, flag))
         in :opt_and, { mid: :&, orig_argc: 1, flag: }
           @insns << OptAnd.new(CallData.new(:&, 1, flag))
         in :opt_aref, { mid: :[], orig_argc: 1, flag: }

--- a/lib/yarv/anytostring.rb
+++ b/lib/yarv/anytostring.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `anytostring` ensures that the value on top of the stack is a string.
+  #
+  # It pops two values off the stack. If the first value is a string it pushes it back on
+  # the stack. If the first value is not a string, it uses Ruby's built in string coercion
+  # to coerce the second value to a string and then pushes that back on the stack.
+  #
+  # This is used in conjunction with `objtostring` as a fallback for when an object's `to_s`
+  # method does not return a string
+  #
+  # ### TracePoint
+  #
+  # `anytostring` cannot dispatch any TracePoint events
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # "#{5}"
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
+  # # 0000 putobject                              ""                        (   1)[Li]
+  # # 0002 putobject                              5
+  # # 0004 dup
+  # # 0005 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
+  # # 0007 anytostring
+  # # 0008 concatstrings                          2
+  # # 0010 leave
+  # ~~~
+  #
+  class AnyToString
+    def call(context)
+      maybe_string, orig_val = context.stack.pop(2)
+      string = maybe_string.is_a?(String) ? maybe_string : orig_val.to_s
+      context.stack.push(string)
+    end
+
+    def to_s
+      "anytostring"
+    end
+  end
+end

--- a/lib/yarv/concatstrings.rb
+++ b/lib/yarv/concatstrings.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `concatstrings` just pops a number of strings from the stack joins them together
+  # into a single string and pushes that string back on the stack.
+  #
+  # This does no coercion and so is always used in conjunction with `objtostring`
+  # and `anytostring` to ensure the stack contents are always strings
+  #
+  # ### TracePoint
+  #
+  # `concatstrings` can dispatch the `line` and `call` events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # "#{5}"
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
+  # # 0000 putobject                              ""                        (   1)[Li]
+  # # 0002 putobject                              5
+  # # 0004 dup
+  # # 0005 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
+  # # 0007 anytostring
+  # # 0008 concatstrings                          2
+  # # 0010 leave
+  # ~~~
+  #
+  class ConcatStrings
+    attr_reader :num
+
+    def initialize(num)
+      @num = num
+    end
+
+    def call(context)
+      strings = context.stack.pop(num)
+      context.stack.push(strings.join)
+    end
+
+    def to_s
+      "%-38s %s" % ["concatstrings", num]
+    end
+  end
+end

--- a/lib/yarv/objtostring.rb
+++ b/lib/yarv/objtostring.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `objtostring` pops a value from the stack, calls `to_s` on that value and then pushes
+  # the result back to the stack.
+  #
+  # It has fast paths for String, Symbol, Module, Class, Nil, True, False & Number.
+  # For everything else it calls `to_s`
+  #
+  # ### TracePoint
+  #
+  # `objtostring` cannot dispatch any TracePoint events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # "#{5}"
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
+  # # 0000 putobject                              ""                        (   1)[Li]
+  # # 0002 putobject                              5
+  # # 0004 dup
+  # # 0005 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
+  # # 0007 anytostring
+  # # 0008 concatstrings                          2
+  # # 0010 leave
+  # ~~~
+  #
+  class ObjToString
+    attr_reader :call_data
+
+    def initialize(call_data)
+      @call_data = call_data
+    end
+
+    def call(context)
+      obj = context.stack.pop
+      result = context.call_method(call_data, obj, [])
+
+      context.stack.push(result)
+    end
+
+    def to_s
+      "%-38s %s" % ["objtostring", call_data]
+    end
+  end
+end

--- a/test/anytostring_test.rb
+++ b/test/anytostring_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class AnyToStringTest < TestCase
+    def test_execute
+      assert_insns(
+        [
+          PutObject,
+          PutObject,
+          Dup,
+          ObjToString,
+          AnyToString,
+          ConcatStrings,
+          Leave
+        ],
+        '"#{5}"'
+      )
+      assert_stdout("\"5\"\n", 'p "#{5}"')
+    end
+
+    def test_produces_the_expected_instructions
+      assert_stdout_for_instructions(
+        "5\n",
+        [
+          [:putself],
+          [:putobject, ""],
+          [:putobject, 5],
+          [:dup],
+          [:objtostring, { mid: :to_s, flag: 20, orig_argc: 0 }],
+          [:anytostring],
+          [:concatstrings, 2],
+          [:opt_send_without_block, { mid: :puts, flag: 20, orig_argc: 1 }],
+          [:leave]
+        ]
+      )
+    end
+  end
+end

--- a/test/concatstrings_test.rb
+++ b/test/concatstrings_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class ConcatstringsTest < TestCase
+    def test_execute
+      assert_insns(
+        [
+          PutObject,
+          PutObject,
+          Dup,
+          ObjToString,
+          AnyToString,
+          ConcatStrings,
+          Leave
+        ],
+        '"#{5}"'
+      )
+      assert_stdout("\"5\"\n", 'p "#{5}"')
+    end
+
+    def test_produces_the_expected_instructions
+      assert_stdout_for_instructions(
+        "5\n",
+        [
+          [:putself],
+          [:putobject, ""],
+          [:putobject, 5],
+          [:dup],
+          [:objtostring, { mid: :to_s, flag: 20, orig_argc: 0 }],
+          [:anytostring],
+          [:concatstrings, 2],
+          [:opt_send_without_block, { mid: :puts, flag: 20, orig_argc: 1 }],
+          [:leave]
+        ]
+      )
+    end
+  end
+end

--- a/test/objtostring_test.rb
+++ b/test/objtostring_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class ObjToStringTest < TestCase
+    def test_execute
+      assert_insns(
+        [
+          PutObject,
+          PutObject,
+          Dup,
+          ObjToString,
+          AnyToString,
+          ConcatStrings,
+          Leave
+        ],
+        '"#{5}"'
+      )
+      assert_stdout("\"5\"\n", 'p "#{5}"')
+    end
+
+    def test_produces_the_expected_instructions
+      assert_stdout_for_instructions(
+        "5\n",
+        [
+          [:putself],
+          [:putobject, ""],
+          [:putobject, 5],
+          [:dup],
+          [:objtostring, { mid: :to_s, flag: 20, orig_argc: 0 }],
+          [:anytostring],
+          [:concatstrings, 2],
+          [:opt_send_without_block, { mid: :puts, flag: 20, orig_argc: 1 }],
+          [:leave]
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes #140, #142, #148 

`concatstrings`, `anytostring` and `objtostring` are implemented together because they are always called together e.g.

```
➜  ruby --dump=insns -e '"#{5}"'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
0000 putobject                              ""                        (   1)[Li]
0002 putobject                              5
0004 dup
0005 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
0007 anytostring
0008 concatstrings                          2
0010 leave

➜  exe/yarv --dump=insns -e '"#{5}"'
== disasm #<ISeq:<compiled>>
0000 putobject                              ""
0000 putobject                              5
0000 dup
0000 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
0000 anytostring
0000 concatstrings                          2
0000 leave
```

Co-authored-by: Matt Valentine-House <matt.valentinehouse@shopify.com>